### PR TITLE
Fix sliderBuilder talk's initial state.duration.

### DIFF
--- a/src/components/SliderBuilder.js
+++ b/src/components/SliderBuilder.js
@@ -24,7 +24,7 @@ const SliderBuilder = (props) => {
       talkTitle: "",
       talkHelperText: "",
       talkError: false,
-      talkDuration: "",
+      talkDuration: "5",
       isLightning: true,
     },
   ]);
@@ -136,7 +136,7 @@ const SliderBuilder = (props) => {
     const values = [...inputFields];
     let newinput = {
       talkTitle: "",
-      talkDuration: "",
+      talkDuration: "5",
       isLightning: true,
       talkHelperText: "",
       talkError: false,


### PR DESCRIPTION
* In sliderBuilder.js Talks had an initial state.duration of " ". This means that when the user didn't move the slider and just clicked to schedule conference, the submitted value would be " " and it wouldn't increment the Track by it's duration (5 minutes).
* Fixed by changing 2 lines of code and setting Talk's initial state.duration to 5 minutes.